### PR TITLE
Allow No Empty Line Before Rules After Comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This is a list of the lints turned on in this configuration (beyond the ones tha
 
 #### Rule
 
--   [`rule-empty-line-before`](https://github.com/stylelint/stylelint/blob/master/lib/rules/rule-empty-line-before/): Require an empty line before multi-line rules. _overriding SUIT rule to exclude the first multi-line rule in a block._
+-   [`rule-empty-line-before`](https://github.com/stylelint/stylelint/blob/master/lib/rules/rule-empty-line-before/): Require an empty line before multi-line rules. _overriding SUIT rule to exclude the first multi-line rule in a block, and to ignore rules following comments._
 
 ## [Changelog](CHANGELOG.md)
 

--- a/index.js
+++ b/index.js
@@ -26,7 +26,8 @@ module.exports = {
     "rule-empty-line-before": [
       "always-multi-line",
       {
-        except: ["first-nested"]
+        except: ["first-nested"],
+        ignore: ["after-comment"]
       }
     ]
   }


### PR DESCRIPTION
This commit adds the "ignore after comments" condition to the `rule-empty-line-before` rule. As configured, the rule will require an empty line before multi-line rules, unless that rule is the first nested rule. Further, the rule will be ignored following comments, which allows for no blank line between comments and rules, but also won't immediately break linting for existing stylesheets.

Fixes #6