### PR TITLE
Add `include` to at-rule-empty-line-before ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This is a list of the lints turned on in this configuration (beyond the ones tha
 
 #### At-rule
 
--   [`at-rule-empty-line-before`](https://github.com/stylelint/stylelint/blob/master/lib/rules/at-rule-empty-line-before/): Require an empty line before at-rules, except blockless after blockless. _overriding SUIT rule to further exclude `@custom-media`, `@mixin`, `@import`, and `@for` rules._
+-   [`at-rule-empty-line-before`](https://github.com/stylelint/stylelint/blob/master/lib/rules/at-rule-empty-line-before/): Require an empty line before at-rules, except blockless after blockless. _overriding SUIT rule to further exclude `@custom-media`, `@mixin`, `@include`, `@import`, and `@for` rules._
 
 #### Comments
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This is a list of the lints turned on in this configuration (beyond the ones tha
 
 #### At-rule
 
--   [`at-rule-empty-line-before`](https://github.com/stylelint/stylelint/blob/master/lib/rules/at-rule-empty-line-before/): Require an empty line before at-rules, except blockless after blockless. _overriding SUIT rule to further exclude `@custom-media`, `@mixin`, `@include`, `@import`, and `@for` rules._
+-   [`at-rule-empty-line-before`](https://github.com/stylelint/stylelint/blob/master/lib/rules/at-rule-empty-line-before/README.md): Require an empty line before at-rules. _disabled temporarily, pending [#2480](https://github.com/stylelint/stylelint/issues/2480)_
 
 #### Comments
 

--- a/index.js
+++ b/index.js
@@ -3,13 +3,7 @@
 module.exports = {
   extends: "stylelint-config-suitcss",
   rules: {
-    "at-rule-empty-line-before": [
-      "always",
-      {
-        except: ["blockless-after-blockless"],
-        ignoreAtRules: ["custom-media", "mixin", "include", "import", "for"]
-      }
-    ],
+    "at-rule-empty-line-before": null,
     "comment-empty-line-before": [
       "always",
       {

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
       "always",
       {
         except: ["blockless-after-blockless"],
-        ignoreAtRules: ["custom-media", "mixin", "import", "for"]
+        ignoreAtRules: ["custom-media", "mixin", "include", "import", "for"]
       }
     ],
     "comment-empty-line-before": [


### PR DESCRIPTION
This commit adds `include` to the list of at-rules that the
`at-rule-empty-line-before` rule ignores. This allows you to have an
`@include` statement at the top of a CSS rule without needing an
empty line between it and the following statements.

Fixes #7