### PR TITLE
Update Stylelint "Using with Prettier" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ You'll probably also want to add a script to your `package.json` file to make it
 
 ### Using with Prettier
 
+> [!NOTE]
+> This section is no longer relevant if you are using **Stylelint V15** or higher.
+
+>  As of Stylelint v15 [all style-related rules have been deprecated](https://stylelint.io/migration-guide/to-15#deprecated-stylistic-rules). If you are using v15 or higher and are not making use of these deprecated rules, [this plugin is no longer necessary](https://stylelint.io/migration-guide/to-15#:~:text=Additionally%2C%20you%20may%20no%20longer%20need%20to%20extend%20Prettier%27s%20Stylelint%20config).
+
 It's common to [pair Stylelint with Prettier](https://prettier.io/docs/en/integrating-with-linters.html#stylelint). If you're going to use both, you'll want to add [`stylelint-config-prettier`](https://github.com/prettier/stylelint-config-prettier), which is a config that disables any Stylelint rules that conflict with Prettier.
 
 ```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You'll probably also want to add a script to your `package.json` file to make it
 > [!NOTE]
 > This section is no longer relevant if you are using **Stylelint V15** or higher.
 
->  As of Stylelint v15 [all style-related rules have been deprecated](https://stylelint.io/migration-guide/to-15#deprecated-stylistic-rules). If you are using v15 or higher and are not making use of these deprecated rules, [this plugin is no longer necessary](https://stylelint.io/migration-guide/to-15#:~:text=Additionally%2C%20you%20may%20no%20longer%20need%20to%20extend%20Prettier%27s%20Stylelint%20config).
+> As of Stylelint v15 [all style-related rules have been deprecated](https://stylelint.io/migration-guide/to-15#deprecated-stylistic-rules). If you are using v15 or higher and are not making use of these deprecated rules, [this plugin is no longer necessary](https://stylelint.io/migration-guide/to-15#:~:text=Additionally%2C%20you%20may%20no%20longer%20need%20to%20extend%20Prettier%27s%20Stylelint%20config).
 
 It's common to [pair Stylelint with Prettier](https://prettier.io/docs/en/integrating-with-linters.html#stylelint). If you're going to use both, you'll want to add [`stylelint-config-prettier`](https://github.com/prettier/stylelint-config-prettier), which is a config that disables any Stylelint rules that conflict with Prettier.
 


### PR DESCRIPTION
As of Styleline V15, we no longer need `stylelint-config-prettier`. I decided to add a note because I got tripped up again following our setup steps. 